### PR TITLE
Render map name and edit map color in county level

### DIFF
--- a/client/src/components/screens/map/display/MapScreen.js
+++ b/client/src/components/screens/map/display/MapScreen.js
@@ -18,6 +18,7 @@ function MapScreen() {
   const [color, setColor] = useState("#fff");
   const colorRef = useRef();
   const [initialLoad, setInitialLoad] = useState(true);
+  const [regionNameLevel, setRegionNameLevel] = useState("");
 
   useEffect(() => {
     colorRef.current = mapInfo?.currentRegionColor;
@@ -26,6 +27,21 @@ function MapScreen() {
   useEffect(() => {
     mapContentRef.current = mapInfo?.currentMap?.mapContent;
   }, [mapInfo?.currentMap?.mapContent]);
+
+  useEffect(() => {
+    const individualProperties = mapContentRef?.current[0]?.properties;
+    let name = individualProperties.ID_3
+      ? "name_3"
+      : individualProperties.ID_2
+      ? "name_2"
+      : individualProperties.ID_1
+      ? "name_1"
+      : individualProperties.ID_0
+      ? "name_0"
+      : "name";
+    
+      setRegionNameLevel(name);
+  }, []);
 
   if (!mapInfo || !mapContentRef?.current) {
     return null;
@@ -40,22 +56,21 @@ function MapScreen() {
 
     // update mapcontent ref
     const index = mapContentRef.current.findIndex(
-      (region) => region.properties.name === layer.feature.properties.name
+      (region) => region.properties[regionNameLevel] === layer.feature.properties[regionNameLevel]
     );
     if (index !== -1) {
       mapContentRef.current[index].properties.fillColor = colorRef.current;
-    } 
+    }
 
     mapInfo.updateMapContent(index, colorRef.current);
   };
 
   const onEachFeature = (feature, layer) => {
     layer
-      .bindTooltip(layer.feature.properties.name, {
+      .bindTooltip(layer.feature.properties[regionNameLevel], {
         permanent: true,
       })
       .openTooltip();
-    layer.bindTooltip(layer.feature.properties.name).openTooltip();
     if (layer.feature.properties.fillColor) {
       layer.setStyle({
         fillColor: layer.feature.properties.fillColor,

--- a/client/src/components/screens/map/display/MapScreen.js
+++ b/client/src/components/screens/map/display/MapScreen.js
@@ -29,6 +29,10 @@ function MapScreen() {
   }, [mapInfo?.currentMap?.mapContent]);
 
   useEffect(() => {
+    if(!mapContentRef?.current){
+      return;
+    }
+
     const individualProperties = mapContentRef?.current[0]?.properties;
     let name = individualProperties.ID_3
       ? "name_3"

--- a/client/src/contexts/map/index.js
+++ b/client/src/contexts/map/index.js
@@ -505,11 +505,10 @@ export function MapContextProvider({ children }) {
   };
 
   mapInfo.updateMapGeneralInfo = function (title, tags) {
-    if (!mapInfo.map) {
+    if (!mapInfo.currentMap) {
       return;
     }
-    console.log(mapInfo.map);
-    let oldMap = mapInfo.map;
+    let oldMap = mapInfo.currentMap;
     if (title) {
       oldMap.title = title;
     }
@@ -527,9 +526,7 @@ export function MapContextProvider({ children }) {
   };
 
   mapInfo.updateMapById = async function (mapId) {
-    console.log(mapInfo.map);
     const response = await api.updateMapById(mapId, mapInfo.map);
-    console.log(response);
     if (response.status === 200) {
       await mapInfo.getAllUserMaps();
       navigate("/");


### PR DESCRIPTION
1. Previously region name only renders if map is country level, made it so that it's compatible with county level as well
2. Able to edit region color for county level maps